### PR TITLE
Bugfix for sourceUrl const definition

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-const sourcesUrl = "${process.env.MAPSERVER_URL}";
+const sourcesUrl = `${process.env.MAPSERVER_URL}`;
 const glyphsUrl = `file://${process.env.WORK}/node_modules/hsl-map-style/`;
 
 module.exports = {


### PR DESCRIPTION
Replaced double quotes to backticks